### PR TITLE
fix: replace silent catch with error logging

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -72,7 +72,7 @@ client.on("guildCreate", guild => {
   console.info(`Added to ${guild.name} (${guild.id})`);
   guild?.systemChannel
     ?.send("**Glad to be a part of your server** :heart:\nYou're probably looking for `/help`")
-    .catch(() => {});
+    .catch(err => console.error("Failed to send guild welcome message:", err.message));
 });
 
 client.on("guildDelete", guild => {


### PR DESCRIPTION
Fixed a bug where the bot silently swallowed errors when failing to send welcome messages. Now properly logs the error for debugging.